### PR TITLE
Adding new exceptions and attributes to control the DI system

### DIFF
--- a/Powershell5.DI/Powershell5.DI/CmdletBase/DiBasePsCmdlet.cs
+++ b/Powershell5.DI/Powershell5.DI/CmdletBase/DiBasePsCmdlet.cs
@@ -11,6 +11,7 @@
 // </copyright>
 // <summary>The base class for use with cmdlets that want Dependance Injection and want to derive them selves from the PSCmdlet Base Class</summary>
 // ***********************************************************************
+
 namespace UTMO.Powershell5.DI.CmdletBase
 {
     using System;
@@ -18,92 +19,94 @@ namespace UTMO.Powershell5.DI.CmdletBase
     using System.Linq;
     using System.Management.Automation;
     using System.Reflection;
-    using DI;
+
+    using UTMO.Powershell5.DI.DI;
 
     /// <summary>
-    /// Class DiBasePsCmdlet.
-    /// Implements the <see cref="System.Management.Automation.PSCmdlet" />
+    ///     Class DiBasePsCmdlet.
+    ///     Implements the <see cref="System.Management.Automation.PSCmdlet" />
     /// </summary>
     /// <seealso cref="System.Management.Automation.PSCmdlet" />
     public class DiBasePsCmdlet : PSCmdlet
     {
         /// <summary>
-        /// This method replaces the call you would make to the "BeginProcessing" method on the <see cref="PSCmdlet"/> class.
+        ///     This method replaces the call you would make to the "BeginProcessing" method on the <see cref="PSCmdlet" /> class.
         /// </summary>
         protected virtual void BeginCmdletProcessing()
         {
         }
 
         /// <summary>
-        /// This method replaces the call you would make to the "ProcessRecord" method on the <see cref="PSCmdlet"/> class.
+        ///     Overrides the BeginProcessing method from the base class.  In this method we perform the act of injection
+        ///     dependencies in to properties and fields
+        ///     decorated with the <see cref="ShouldInjectAttribute" />.
         /// </summary>
-        protected virtual void ProcessCmdletRecord()
+        protected override sealed void BeginProcessing()
         {
-        }
-
-        /// <summary>
-        /// This method replaces the call you would make to the "EndProcessing" method on the <see cref="PSCmdlet"/> class.
-        /// </summary>
-        protected virtual void EndCmdletProcessing()
-        {
-        }
-
-        /// <summary>
-        /// This method replaces the call you would make to the "StopProcessing" method on the <see cref="PSCmdlet"/> class.
-        /// </summary>
-        protected virtual void StopCmdletProcessing()
-        {
-        }
-
-        /// <summary>
-        /// Overrides the BeginProcessing method from the base class.  In this method we perform the act of injection dependencies in to properties and fields
-        /// decorated with the <see cref="ShouldInjectAttribute"/>.
-        /// </summary>
-        protected sealed override void BeginProcessing()
-        {
-            if (this.GetType()
-                    .GetProperties(BindingFlags.NonPublic)
-                    .Where(
-                           p => p.CustomAttributes.Any(a => a.AttributeType == typeof(ShouldInjectAttribute))
-                           ) is List<PropertyInfo> injectableProperties
-                    && injectableProperties.Any())
-            {
+            if (this.GetType().GetProperties(BindingFlags.NonPublic).Where(
+                        p => p.CustomAttributes.Any(a => a.AttributeType == typeof(ShouldInjectAttribute))) is
+                    List<PropertyInfo> injectableProperties && injectableProperties.Any())
                 foreach (var property in injectableProperties)
                 {
                     // ReSharper disable once SuggestVarOrType_BuiltInTypes
                     string resolverName = property.GetCustomAttribute<ShouldInjectAttribute>().Name;
                     var targetType = property.PropertyType;
 
-                    var instance = string.IsNullOrWhiteSpace(resolverName) ? InternalContainer.Container.Value.Resolve(targetType) : InternalContainer.Container.Value.Resolve(targetType, resolverName);
+                    var instance = string.IsNullOrWhiteSpace(resolverName)
+                                       ? InternalContainer.Container.Value.Resolve(targetType)
+                                       : InternalContainer.Container.Value.Resolve(targetType, resolverName);
 
                     property.SetValue(property, instance);
                 }
-            }
 
             this.BeginCmdletProcessing();
         }
 
         /// <summary>
-        /// Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a uniform naming convention for class
-        /// methods
+        ///     This method replaces the call you would make to the "EndProcessing" method on the <see cref="PSCmdlet" /> class.
         /// </summary>
-        protected sealed override void ProcessRecord()
+        protected virtual void EndCmdletProcessing()
         {
-            this.ProcessCmdletRecord();
         }
 
         /// <summary>
-        /// Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a uniform naming convention for class
-        /// methods
+        ///     Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a
+        ///     uniform naming convention for class
+        ///     methods
         /// </summary>
-        protected sealed override void EndProcessing()
+        protected override sealed void EndProcessing()
         {
             this.EndCmdletProcessing();
         }
 
         /// <summary>
-        /// Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a uniform naming convention for class
-        /// methods
+        ///     This method replaces the call you would make to the "ProcessRecord" method on the <see cref="PSCmdlet" /> class.
+        /// </summary>
+        protected virtual void ProcessCmdletRecord()
+        {
+        }
+
+        /// <summary>
+        ///     Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a
+        ///     uniform naming convention for class
+        ///     methods
+        /// </summary>
+        protected override sealed void ProcessRecord()
+        {
+            this.ProcessCmdletRecord();
+        }
+
+        /// <summary>
+        ///     This method replaces the call you would make to the "StopProcessing" method on the <see cref="PSCmdlet" /> class.
+        /// </summary>
+        protected virtual void StopCmdletProcessing()
+        {
+        }
+
+        /// <summary>
+        ///     Overrides the base class implementation.  Well I have no plans to add logic here it's been overriden to provide a
+        ///     uniform naming convention for class
+        ///     methods
         /// </summary>
         protected override void StopProcessing()
         {
@@ -111,36 +114,36 @@ namespace UTMO.Powershell5.DI.CmdletBase
         }
 
         /// <summary>
-        /// This class is used to decorate properties and fields that require dependency injection.
-        /// This class cannot be inherited.
-        /// Implements the <see cref="System.Attribute" />
+        ///     This class is used to decorate properties and fields that require dependency injection.
+        ///     This class cannot be inherited.
+        ///     Implements the <see cref="System.Attribute" />
         /// </summary>
         /// <seealso cref="System.Attribute" />
-        [AttributeUsage(AttributeTargets.Field | AttributeTargets.GenericParameter | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+        [AttributeUsage(AttributeTargets.Field | AttributeTargets.GenericParameter | AttributeTargets.Property)]
         protected sealed class ShouldInjectAttribute : Attribute
         {
             /// <summary>
-            /// Gets or sets the name.
-            /// </summary>
-            /// <value>The name specified for a registered type with the DI container that you want retrieved.</value>
-            /// <remarks>This is useful only when you are using named dependencies in your container.</remarks>
-            public string Name { get; set; }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="ShouldInjectAttribute" /> class.
+            ///     Initializes a new instance of the <see cref="ShouldInjectAttribute" /> class.
             /// </summary>
             public ShouldInjectAttribute()
             {
             }
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="ShouldInjectAttribute" /> class.
+            ///     Initializes a new instance of the <see cref="ShouldInjectAttribute" /> class.
             /// </summary>
             /// <param name="name">The name.</param>
             public ShouldInjectAttribute(string name)
             {
                 this.Name = name;
             }
+
+            /// <summary>
+            ///     Gets or sets the name.
+            /// </summary>
+            /// <value>The name specified for a registered type with the DI container that you want retrieved.</value>
+            /// <remarks>This is useful only when you are using named dependencies in your container.</remarks>
+            public string Name { get; set; }
         }
     }
 }

--- a/Powershell5.DI/Powershell5.DI/DI/IPowerShellDiContainer.cs
+++ b/Powershell5.DI/Powershell5.DI/DI/IPowerShellDiContainer.cs
@@ -72,20 +72,20 @@ namespace UTMO.Powershell5.DI.DI
         void Register(Type abstraction, Type implementation, string name);
 
         /// <summary>
-        /// Registers the singleton.
+        /// Registers a singleton.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">The type of the singleton being registered</typeparam>
         void RegisterSingleton<T>();
 
         /// <summary>
-        /// Registers the singleton.
+        /// Registers a singleton.
         /// </summary>
         /// <typeparam name="TInterface">The type of the t interface.</typeparam>
         /// <typeparam name="TImplementation">The type of the t implementation.</typeparam>
         void RegisterSingleton<TInterface, TImplementation>()
             where TImplementation : class, TInterface;
 
-        /// <summary>Registers the singleton.</summary>
+        /// <summary>Registers a singleton.</summary>
         /// <typeparam name="TInterface">The Interface Being Registered</typeparam>
         /// <typeparam name="TImplementation">The Objecting being mapped to the interface</typeparam>
         /// <param name="factoryMethod">The factory method.</param>
@@ -120,7 +120,7 @@ namespace UTMO.Powershell5.DI.DI
         /// Resolves the specified type.
         /// </summary>
         /// <param name="type">The type.</param>
-        /// <returns>System.Object.</returns>
+        /// <returns>The registered type boxed in an <see cref="object"/>.</returns>
         object Resolve(Type type);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace UTMO.Powershell5.DI.DI
         /// </summary>
         /// <param name="type">The type.</param>
         /// <param name="name">The name.</param>
-        /// <returns>System.Object.</returns>
+        /// <returns>The registered type with the specified name boxed in an <see cref="object"/>.</returns>
         object Resolve(Type type, string name);
     }
 }

--- a/Powershell5.DI/Powershell5.DI/DI/PowerShellDiContainerAttribute.cs
+++ b/Powershell5.DI/Powershell5.DI/DI/PowerShellDiContainerAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace UTMO.Powershell5.DI.DI
+{
+    using System;
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class PowerShellDiContainerAttribute : Attribute
+    {
+    }
+}

--- a/Powershell5.DI/Powershell5.DI/Exceptions/ContainerNotFoundException.cs
+++ b/Powershell5.DI/Powershell5.DI/Exceptions/ContainerNotFoundException.cs
@@ -1,0 +1,14 @@
+﻿namespace UTMO.Powershell5.DI.Exceptions
+{
+    using System;
+
+    using UTMO.Powershell5.DI.DI;
+
+    public class ContainerNotFoundException : Exception
+    {
+        public ContainerNotFoundException() : base($"No containers were found that implement the {nameof(IPowerShellDiContainer)} interface.")
+        {
+            
+        }
+    }
+}

--- a/Powershell5.DI/Powershell5.DI/Exceptions/TooManyContainersException.cs
+++ b/Powershell5.DI/Powershell5.DI/Exceptions/TooManyContainersException.cs
@@ -1,0 +1,18 @@
+﻿namespace UTMO.Powershell5.DI.Exceptions
+{
+    using System;
+    using System.Collections.Generic;
+
+    using UTMO.Powershell5.DI.DI;
+
+    public class TooManyContainersException : Exception
+    {
+        //// TODO: this message is rather massive and should be optimized away to a resex or strings file
+        public TooManyContainersException(IEnumerable<Type> discoveredTypes) : base($"More then one type was discovered that had the {nameof(PowerShellDiContainerAttribute)} attribute applied.\r\nUpdate your code so that only a single type that has {nameof(PowerShellDiContainerAttribute)} applied to it is present.\r\n For more details check the {nameof(DiscoveredTypes)} property of this exception in PowerShell or a debugger to view what types were discovered with the {nameof(PowerShellDiContainerAttribute)} applied to them.")
+        {
+            this.DiscoveredTypes = discoveredTypes;
+        }
+
+        public IEnumerable<Type> DiscoveredTypes { get; set; }
+    }
+}

--- a/Powershell5.DI/Powershell5.DI/Exceptions/TooManyContainersException.cs
+++ b/Powershell5.DI/Powershell5.DI/Exceptions/TooManyContainersException.cs
@@ -7,7 +7,7 @@
 
     public class TooManyContainersException : Exception
     {
-        //// TODO: this message is rather massive and should be optimized away to a resex or strings file
+        // TODO: this message is rather massive and should be optimized away to a resources or strings file
         public TooManyContainersException(IEnumerable<Type> discoveredTypes) : base($"More then one type was discovered that had the {nameof(PowerShellDiContainerAttribute)} attribute applied.\r\nUpdate your code so that only a single type that has {nameof(PowerShellDiContainerAttribute)} applied to it is present.\r\n For more details check the {nameof(DiscoveredTypes)} property of this exception in PowerShell or a debugger to view what types were discovered with the {nameof(PowerShellDiContainerAttribute)} applied to them.")
         {
             this.DiscoveredTypes = discoveredTypes;

--- a/Powershell5.DI/Powershell5.DI/Powershell5.DI.csproj
+++ b/Powershell5.DI/Powershell5.DI/Powershell5.DI.csproj
@@ -49,6 +49,7 @@
     <Compile Include="DI\InternalContainer.cs" />
     <Compile Include="DI\IPowerShellDiContainer.cs" />
     <Compile Include="DI\PowerShellDiContainerAttribute.cs" />
+    <Compile Include="Exceptions\ContainerNotFoundException.cs" />
     <Compile Include="Exceptions\TooManyContainersException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Powershell5.DI/Powershell5.DI/Powershell5.DI.csproj
+++ b/Powershell5.DI/Powershell5.DI/Powershell5.DI.csproj
@@ -48,6 +48,8 @@
     <Compile Include="CmdletBase\DiBasePsCmdlet.cs" />
     <Compile Include="DI\InternalContainer.cs" />
     <Compile Include="DI\IPowerShellDiContainer.cs" />
+    <Compile Include="DI\PowerShellDiContainerAttribute.cs" />
+    <Compile Include="Exceptions\TooManyContainersException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR includes two new exceptions, one for too many containers discovered and the other for no containers discovered.

Additionally a new attribute has been added to indicate that a specific implementation of IPowerShellDiContainer should be used for DI.